### PR TITLE
C1 devnet: update docs regarding Cardano Testnets support

### DIFF
--- a/docs/cardano/for-developers/index.md
+++ b/docs/cardano/for-developers/index.md
@@ -5,14 +5,7 @@ sidebar_position: 2
 
 # For Developers
 
-:::info
-Milkomeda C1 **Testnet** is not recommended for use at this time due to recent Cardano Testnet developments. New dedicated preview and pre-production Cardano Testnet environments are being introduced and old Testnet is going to be deprecated very soon. Due to that fact there may appear difficulties with moving funds between Cardano and Milkomeda C1 Sidechain (Testnet). 
-
-Taking this into consideration, we recommend all users who would like to deploy their contracts on Milkomeda C1 Sidechain (Testnet), to perform testing on any other EVM-compatible chain instead. The main issue is that to pay the fees on Milkomeda C1 Testnet, one must wrap test assets using Cardano Testnet which may not be possible.
-
-Thanks to Milkomeda C1 EVM-compatibility, such contracts can be deployed on any Ethereum Virtual Machine, so even if a contract is tested elsewhere, it will work on the Milkomeda C1 Sidechain.
-:::
-Two versions of the Milkomeda C1 sidechain are currently operational. One is the devnet version, which uses test ADA and interacts with the Cardano Testnet. The the other is the mainnet version, which uses real ADA and interacts with the Cardano mainnet.
+Two versions of the Milkomeda C1 sidechain are currently operational. One is the devnet version, which uses test ADA and interacts with the Cardano **Preprod** Testnet. The the other is the mainnet version, which uses real ADA and interacts with the Cardano mainnet.
 
 We recommend starting with the devnet to get oriented first. Once you're familiar with the devnet, the operations for mainnet are the same. The example steps that follow will show how to set up a connection to the devnet, with additional sections in red text indicating parameters and steps for using the mainnet.
 

--- a/docs/cardano/for-end-users/index.md
+++ b/docs/cardano/for-end-users/index.md
@@ -5,14 +5,6 @@ sidebar_position: 2
 
 # For End Users
 
-:::info
-Milkomeda C1 **Testnet** is not recommended for use at this time due to recent Cardano Testnet developments. New dedicated preview and pre-production Cardano Testnet environments are being introduced and old Testnet is going to be deprecated very soon. Due to that fact there may appear difficulties with moving funds between Cardano and Milkomeda C1 Sidechain (Testnet). 
-
-Taking this into consideration, we recommend all users who would like to deploy their contracts on Milkomeda C1 Sidechain (Testnet), to perform testing on any other EVM-compatible chain instead. The main issue is that to pay the fees on Milkomeda C1 Testnet, one must wrap test assets using Cardano Testnet which may not be possible.
-
-Thanks to Milkomeda C1 EVM-compatibility, such contracts can be deployed on any Ethereum Virtual Machine, so even if a contract is tested elsewhere, it will work on the Milkomeda C1 Sidechain.
-:::
-
 The Milkomeda C1 sidechain uses MilkADA as its base asset for paying fees and gas. To access the sidechain, you will need a Cardano wallet with some ADA as well as the MetaMask browser extension.
 
 On the following pages we will walk through the steps to create a Cardano wallet in Flint, configure MetaMask to get a Milkomeda C1 address, and finally send ADA to be converted into MilkADA on Milkomeda C1.

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -48,8 +48,7 @@ End users can send ADA from the Cardano mainnet to a bridge address and receive 
 
 ## [For Developers](./cardano/for-developers/)
 
-In addition to the mainnet version of the Milkomeda C1 sidechain which uses wrapped ADA for fees and gas, developers can also access the **Milkomeda Devnet** to wrap assets from the Cardano Testnet and deploy smart contracts on the Milkomeda C1 Devnet sidechain using wrapped Test ADA for fees and gas. Proceed to the next page to start by setting up Flint Wallet and obtaining some test ADA from the Cardano Testnet faucet.
-
+In addition to the mainnet version of the Milkomeda C1 sidechain which uses wrapped ADA for fees and gas, developers can also access the **Milkomeda Devnet** to wrap assets from the Cardano Preprod Testnet and deploy smart contracts on the Milkomeda C1 Devnet sidechain using wrapped Test ADA for fees and gas. Proceed to the next page to start by setting up Flint Wallet and obtaining some test ADA from the Cardano Testnet faucet.
 
 ## Getting started for Algorand
 


### PR DESCRIPTION
- [x] remove note that C1 Devnet is not working
- [x] add updates which say that C1 Devnet is updated and working with Cardano `Preprod` Testnet 